### PR TITLE
ENTESB-4531 Remove Artemis from `featuresBoot`

### DIFF
--- a/assemblies/jboss-fuse-karaf/pom.xml
+++ b/assemblies/jboss-fuse-karaf/pom.xml
@@ -247,7 +247,6 @@
                         <feature>camel-mail</feature>
                         <feature>camel-paxlogging</feature>
                         <feature>pax-cdi-weld</feature>
-                        <feature>artemis</feature>
                         <feature>pax-jdbc-pool-narayana</feature>
                         <feature>transaction-manager-narayana</feature>
                         <feature>hawtio</feature>


### PR DESCRIPTION
This removes Artemis from `featuresBoot` in order to make the external broker the default option.

As per discussion in [ENTESB-4531](https://issues.jboss.org/browse/ENTESB-4531).