### PR TITLE
[ENTESB-7219] [ENTESB-6118] : Added a BOM to quickstart and removed parent pom dependency

### DIFF
--- a/quickstarts/custom/pom.xml
+++ b/quickstarts/custom/pom.xml
@@ -26,12 +26,20 @@
         <version>7.0.0.redhat-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.jboss.fuse.quickstarts</groupId>
     <artifactId>custom-distro</artifactId>
     <packaging>pom</packaging>
-    <version>7.0.0.redhat-SNAPSHOT</version>
 
     <name>JBoss Fuse :: Quickstarts :: custom distro</name>
+
+    <properties>
+      <version.net.java.dev.jna>4.4.0</version.net.java.dev.jna>
+      <version.org.apache.karaf>4.2.0-SNAPSHOT</version.org.apache.karaf>
+      <version.org.apache.servicemix.bundles.xalan>2.7.2_3</version.org.apache.servicemix.bundles.xalan>
+      <version.org.apache.servicemix.bundles.xalan-serializer>2.7.2_1</version.org.apache.servicemix.bundles.xalan-serializer>
+      <version.org.apache.servicemix.bundles.xerces>2.11.0_1</version.org.apache.servicemix.bundles.xerces>
+      <version.org.apache.servicemix.specs>2.9.0</version.org.apache.servicemix.specs>
+      <version.org.osgi>6.0.0</version.org.osgi>
+    </properties>
 
     <dependencies>
         <!--

--- a/quickstarts/pom.xml
+++ b/quickstarts/pom.xml
@@ -20,18 +20,62 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.jboss.fuse</groupId>
-        <artifactId>jboss-fuse-parent</artifactId>
-        <version>7.0.0.redhat-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
-    </parent>
-
     <groupId>org.jboss.fuse.quickstarts</groupId>
     <artifactId>quickstarts-parent</artifactId>
+    <version>7.0.0.redhat-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>JBoss Fuse :: Quickstarts :: quickstarts</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <!-- versions of Maven plugins -->
+        <version.plugin.felix.maven-bundle-plugin>3.3.0</version.plugin.felix.maven-bundle-plugin>
+        <version.org.apache.karaf>4.2.0-SNAPSHOT</version.org.apache.karaf>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.fuse</groupId>
+                <artifactId>jboss-fuse-parent</artifactId>
+                <version>7.0.0.redhat-SNAPSHOT</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!-- Felix plugins -->
+
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>${version.plugin.felix.maven-bundle-plugin}</version>
+                    <extensions>true</extensions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <!-- Core plugins -->
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 
     <repositories>
         <repository>


### PR DESCRIPTION
Removed groupId and version in custom disto pom.
This should also make it easier to switch to a one repository per quickstart model if needed.