### PR TITLE
Add a version for the karaf-maven-plugin since the quickstarts don't inherit from fuse-karaf-parent.

### DIFF
--- a/quickstarts/custom/pom.xml
+++ b/quickstarts/custom/pom.xml
@@ -107,6 +107,15 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.karaf.tooling</groupId>
+                    <artifactId>karaf-maven-plugin</artifactId>
+                    <version>${version.org.apache.karaf}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <!--


### PR DESCRIPTION
Add a version for the karaf-maven-plugin since the quickstarts don't inherit from fuse-karaf-parent.

Note : this quickstart is the only quickstart that uses the karaf-maven-plugin so it is the only place in the quickstarts that this change needs to be made.