### PR TITLE
Need to add a cxf version to the quickstarts for the use of cxf-java2wadl-plugin

### DIFF
--- a/quickstarts/cxf/rest/pom.xml
+++ b/quickstarts/cxf/rest/pom.xml
@@ -220,6 +220,7 @@
             <plugin>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-java2wadl-plugin</artifactId>
+                <version>${version.org.apache.cxf}</version>
                 <executions>
                     <execution>
                         <id>parsejavadoc</id>

--- a/quickstarts/cxf/secure-rest/pom.xml
+++ b/quickstarts/cxf/secure-rest/pom.xml
@@ -174,6 +174,7 @@
             <plugin>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-java2wadl-plugin</artifactId>
+                <version>${version.org.apache.cxf}</version>
                 <executions>
                     <execution>
                         <id>process-classes</id>

--- a/quickstarts/pom.xml
+++ b/quickstarts/pom.xml
@@ -33,6 +33,7 @@
 
         <!-- versions of Maven plugins -->
         <version.plugin.felix.maven-bundle-plugin>3.3.0</version.plugin.felix.maven-bundle-plugin>
+        <version.org.apache.cxf>3.1.11.redhat-SNAPSHOT</version.org.apache.cxf>
         <version.org.apache.karaf>4.2.0-SNAPSHOT</version.org.apache.karaf>
     </properties>
 


### PR DESCRIPTION
Need to add a cxf version to the quickstarts for the use of cxf-java2wadl-plugin