### PR TITLE
Remove org.apache.karaf.exception

### DIFF
--- a/assemblies/jboss-fuse-karaf-minimal/pom.xml
+++ b/assemblies/jboss-fuse-karaf-minimal/pom.xml
@@ -213,7 +213,6 @@
                                 org.osgi.framework.bootdelegation property in etc/config.properties
                         -->
                         <!-- lib/endorsed -->
-                        <library>mvn:org.apache.karaf/org.apache.karaf.exception/${version.org.apache.karaf};type:=endorsed</library>
                         <library>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces/${version.org.apache.servicemix.bundles.xerces};type:=endorsed;export:=true;delegate:=true</library>
                         <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxp-api-1.4/${version.org.apache.servicemix.specs};type:=endorsed;export:=true</library>
                         <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxb-api-2.2/${version.org.apache.servicemix.specs};type:=endorsed;export:=true</library>

--- a/assemblies/jboss-fuse-karaf/pom.xml
+++ b/assemblies/jboss-fuse-karaf/pom.xml
@@ -345,7 +345,6 @@
                                 org.osgi.framework.bootdelegation property in etc/config.properties
                         -->
                         <!-- lib/endorsed -->
-                        <library>mvn:org.apache.karaf/org.apache.karaf.exception/${version.org.apache.karaf};type:=endorsed</library>
                         <library>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces/${version.org.apache.servicemix.bundles.xerces};type:=endorsed;export:=true;delegate:=true</library>
                         <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxp-api-1.4/${version.org.apache.servicemix.specs};type:=endorsed;export:=true</library>
                         <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxb-api-2.2/${version.org.apache.servicemix.specs};type:=endorsed;export:=true</library>

--- a/pom.xml
+++ b/pom.xml
@@ -378,11 +378,6 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.karaf</groupId>
-                <artifactId>org.apache.karaf.exception</artifactId>
-                <version>${version.org.apache.karaf}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.karaf</groupId>
                 <artifactId>org.apache.karaf.client</artifactId>
                 <version>${version.org.apache.karaf}</version>
             </dependency>

--- a/quickstarts/custom/pom.xml
+++ b/quickstarts/custom/pom.xml
@@ -261,7 +261,6 @@
                                 org.osgi.framework.bootdelegation property in etc/config.properties
                         -->
                         <!-- lib/endorsed -->
-                        <library>mvn:org.apache.karaf/org.apache.karaf.exception/${version.org.apache.karaf};type:=endorsed</library>
                         <library>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces/${version.org.apache.servicemix.bundles.xerces};type:=endorsed;export:=true;delegate:=true</library>
                         <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxp-api-1.4/${version.org.apache.servicemix.specs};type:=endorsed;export:=true</library>
                         <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxb-api-2.2/${version.org.apache.servicemix.specs};type:=endorsed;export:=true</library>


### PR DESCRIPTION
org.apache.karaf.exception has been removed upstream in karaf, we need to remove it from fuse-karaf.