### PR TITLE
Fixes completion support in fuse-credential-store

### DIFF
--- a/modules/fuse-credential-store/fuse-credential-store-karaf/src/main/java/org/jboss/fuse/credential/store/karaf/command/CredentialStoreProtectionCompletionSupport.java
+++ b/modules/fuse-credential-store/fuse-credential-store-karaf/src/main/java/org/jboss/fuse/credential/store/karaf/command/CredentialStoreProtectionCompletionSupport.java
@@ -18,6 +18,7 @@ package org.jboss.fuse.credential.store.karaf.command;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Set;
 
 import org.apache.karaf.shell.api.action.lifecycle.Service;
@@ -151,12 +152,12 @@ public class CredentialStoreProtectionCompletionSupport implements Completer {
         final int complete = new StringsCompleter(Arrays.stream(supportedOptions).filter(o -> !usedOptions.contains(o))
                 .map(o -> o + "=").toArray(String[]::new)).complete(session, commandLine, candidates);
 
-        if ((complete > 0) && (candidates.size() == 1)) {
-            // the StringCompleter adds a space character if there is only one option, we remove it to have the cursor
-            // right after '=' sign
-            final String singleOption = candidates.get(0);
+        for (final ListIterator<String> i = candidates.listIterator(); i.hasNext();) {
+            String candidate = i.next();
 
-            candidates.set(0, singleOption.substring(0, singleOption.length() - 1));
+            if (candidate.endsWith("= ")) {
+                i.set(candidate.substring(0, candidate.length() - 1));
+            }
         }
 
         return complete;

--- a/modules/fuse-credential-store/fuse-credential-store-karaf/src/test/java/org/jboss/fuse/credential/store/karaf/command/CredentialStoreProtectionCompletionSupportTest.java
+++ b/modules/fuse-credential-store/fuse-credential-store-karaf/src/test/java/org/jboss/fuse/credential/store/karaf/command/CredentialStoreProtectionCompletionSupportTest.java
@@ -59,7 +59,7 @@ public class CredentialStoreProtectionCompletionSupportTest {
         assertThat(completition.complete(NOT_NEEDED, commandLine, candidates)).isEqualTo(37);
 
         assertThat(candidates).containsOnly(Arrays.stream(Security.getProviders()).map(Provider::getName)
-                .filter(p -> p.startsWith("S")).map(p -> "provider=" + p).toArray(String[]::new));
+                .filter(p -> p.startsWith("S")).map(p -> "provider=" + p + " ").toArray(String[]::new));
     }
 
     @Test
@@ -72,7 +72,7 @@ public class CredentialStoreProtectionCompletionSupportTest {
 
         assertThat(completition.complete(NOT_NEEDED, commandLine, candidates)).isEqualTo(37);
 
-        assertThat(candidates).containsOnly("provider");
+        assertThat(candidates).containsOnly("provider=");
     }
 
     @Test
@@ -86,7 +86,7 @@ public class CredentialStoreProtectionCompletionSupportTest {
         assertThat(completition.complete(NOT_NEEDED, commandLine, candidates)).isEqualTo(37);
 
         assertThat(candidates).containsOnly(
-                Arrays.stream(Security.getProviders()).map(p -> "provider=" + p.getName()).toArray(String[]::new));
+                Arrays.stream(Security.getProviders()).map(p -> "provider=" + p.getName() + " ").toArray(String[]::new));
     }
 
     @Test


### PR DESCRIPTION
Modifies both the tests and the implementation, the goal is that the
cursor should be right after `=`, so when completing partial command
line parameters like:

    -provi<tab>

It should be completed to:

    -provider=_

And parameter values like:

    -provider=SunJ<tab>

It should be completed to:

    -provider=SunJCE _