### PR TITLE
[ENTESB-7591] Add slf4j-api to system to prevent error with client script.

### DIFF
--- a/assemblies/jboss-fuse-karaf/pom.xml
+++ b/assemblies/jboss-fuse-karaf/pom.xml
@@ -141,6 +141,11 @@
             <artifactId>quickstarts</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -75,14 +75,14 @@
         -->
 
         <!-- versions of "subprojects" of JBoss Fuse -->
-        <version.io.hawt>2.0.0.fuse-000111</version.io.hawt>
+        <version.io.hawt>2.0.0.fuse-000117</version.io.hawt>
         <version.org.apache.activemq.artemis>2.0.0.amq-700011-redhat-1</version.org.apache.activemq.artemis>
-        <version.org.apache.camel>2.21.0.fuse-000029</version.org.apache.camel>
-        <version.org.apache.cxf>3.1.11.fuse-000171</version.org.apache.cxf>
+        <version.org.apache.camel>2.21.0.fuse-000032</version.org.apache.camel>
+        <version.org.apache.cxf>3.1.11.fuse-000176</version.org.apache.cxf>
         <!-- At some point, Karaf will also use pipeline version -->
         <version.org.apache.karaf>4.2.0.redhat-700-SNAPSHOT</version.org.apache.karaf>
         <version.org.fusesource.camel-sap>6.3.0.redhat-283</version.org.fusesource.camel-sap>
-        <version.extra>2.21.0.fuse-000004</version.extra>
+        <version.extra>2.21.0.fuse-000008</version.extra>
 
         <!-- versions of normal dependencies of JBoss Fuse -->
         <version.com.fasterxml.jackson.module>2.8.8</version.com.fasterxml.jackson.module>

--- a/quickstarts/pom.xml
+++ b/quickstarts/pom.xml
@@ -32,7 +32,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- versions of "subprojects" of JBoss Fuse -->
-        <version.org.apache.cxf>3.1.11.fuse-000152</version.org.apache.cxf>
+        <version.org.apache.cxf>3.1.11.fuse-000176</version.org.apache.cxf>
         <version.org.apache.karaf>4.2.0.redhat-700-SNAPSHOT</version.org.apache.karaf>
 
         <!-- versions of Maven plugins -->


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-7591

Also update versions of the fuse pipeline dependencies since some have disappeared.