### PR TITLE
Remove version.org.apache.karaf property - it is defined in the quickstart parent

### DIFF
--- a/quickstarts/custom/pom.xml
+++ b/quickstarts/custom/pom.xml
@@ -33,7 +33,6 @@
 
     <properties>
       <version.net.java.dev.jna>4.4.0</version.net.java.dev.jna>
-      <version.org.apache.karaf>4.2.0.redhat-700-SNAPSHOT</version.org.apache.karaf>
       <version.org.apache.servicemix.bundles.xalan>2.7.2_3</version.org.apache.servicemix.bundles.xalan>
       <version.org.apache.servicemix.bundles.xalan-serializer>2.7.2_1</version.org.apache.servicemix.bundles.xalan-serializer>
       <version.org.apache.servicemix.bundles.xerces>2.11.0_1</version.org.apache.servicemix.bundles.xerces>


### PR DESCRIPTION
Remove the version.org.apache.karaf property from the custom quickstart - it is defined and can be inherited from the quickstart parent.