### PR TITLE
ENTESB-7737 - Unable to install camel-bean-validator

### DIFF
--- a/assemblies/fuse-karaf-framework/src/main/filtered-resources/resources/etc/org.apache.karaf.features.xml
+++ b/assemblies/fuse-karaf-framework/src/main/filtered-resources/resources/etc/org.apache.karaf.features.xml
@@ -85,7 +85,7 @@
                 replacement="mvn:org.atmosphere/atmosphere-runtime/${version.org.atmosphere}" mode="maven" />
         <bundle originalUri="mvn:org.glassfish.web/javax.el/[2,3)"
                 replacement="mvn:org.glassfish.web/javax.el/${version.org.glassfish.web.javax.el}" mode="maven" />
-        <bundle originalUri="mvn:org.hibernate/hibernate-validator/[5.2,6)"
+        <bundle originalUri="mvn:org.hibernate/hibernate-validator/[5.2,5.3)"
                 replacement="mvn:org.hibernate/hibernate-validator/${version.org.hibernate.validator}" mode="maven" />
         <bundle originalUri="mvn:org.javassist/javassist/[3,4)"
                 replacement="mvn:org.javassist/javassist/${version.org.javassist}" mode="maven" />


### PR DESCRIPTION
This is required because Camel is using Hibernate-validator 5.4.2 

https://github.com/jboss-fuse/camel/blob/master/parent/pom.xml#L298

So I have to shrink the hibernate-validator version range.