### PR TITLE
Upgrade camel and cxf to reflect opensaml upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
         <!-- versions of "subprojects" of JBoss Fuse -->
         <version.io.hawt>2.0.0.fuse-000117</version.io.hawt>
         <version.org.apache.activemq.artemis>2.4.0.amq-710004-redhat-1</version.org.apache.activemq.artemis>
-        <version.org.apache.camel>2.21.0.fuse-000051</version.org.apache.camel>
-        <version.org.apache.cxf>3.1.11.fuse-000195</version.org.apache.cxf>
+        <version.org.apache.camel>2.21.0.fuse-000052</version.org.apache.camel>
+        <version.org.apache.cxf>3.1.11.fuse-000196</version.org.apache.cxf>
         <version.org.apache.karaf>4.2.0.fuse-000188</version.org.apache.karaf>
         <version.org.fusesource.camel-sap>7.0.0.fuse-000183</version.org.fusesource.camel-sap>
         <version.org.apache-extras.camel-extra>2.21.0.fuse-000028</version.org.apache-extras.camel-extra>


### PR DESCRIPTION
000159 build was failing with:
```
2018-03-08 11:04:20,845 | ERROR | activator-1-thread-2 | .a.k.f.i.s.BootFeaturesInstaller | 11 - org.apache.karaf.features.core - 4.2.0.fuse-000189 | Error installing boot features
org.osgi.service.resolver.ResolutionException: Unable to resolve root: missing requirement [root] osgi.identity; osgi.identity=cxf; type=karaf.feature; version="[3.1.11.fuse-000195,3.1.11.fuse-000195]"; filter:="(&(osgi.identity=cxf)(type=karaf.feature)(version>=3.1.11.fuse-000195)(version<=3.1.11.fuse-000195))" [caused by: Unable to resolve cxf/3.1.11.fuse-000195: missing requirement [cxf/3.1.11.fuse-000195] osgi.identity; osgi.identity=cxf-ws-rm; type=karaf.feature; version="[3.1.11.fuse-000195,3.1.11.fuse-000195]" [caused by: Unable to resolve cxf-ws-rm/3.1.11.fuse-000195: missing requirement [cxf-ws-rm/3.1.11.fuse-000195] osgi.identity; osgi.identity=cxf-ws-security; type=karaf.feature; version="[3.1.11.fuse-000195,3.1.11.fuse-000195]" [caused by: Unable to resolve cxf-ws-security/3.1.11.fuse-000195: missing requirement [cxf-ws-security/3.1.11.fuse-000195] osgi.identity; osgi.identity=org.apache.cxf.cxf-rt-ws-security; type=osgi.bundle; version="[3.1.11.fuse-000195,3.1.11.fuse-000195]"; resolution:=mandatory [caused by: Unable to resolve org.apache.cxf.cxf-rt-ws-security/3.1.11.fuse-000195: missing requirement [org.apache.cxf.cxf-rt-ws-security/3.1.11.fuse-000195] osgi.wiring.package; filter:="(&(osgi.wiring.package=org.opensaml.saml.common)(version>=3.1.0)(!(version>=4.0.0)))" [caused by: Unable to resolve org.apache.servicemix.bundles.opensaml/3.1.1.3: missing requirement [org.apache.servicemix.bundles.opensaml/3.1.1.3] osgi.wiring.package; filter:="(&(osgi.wiring.package=com.google.common.base)(version>=18.0.0)(!(version>=19.0.0)))"]]]]]
```
and we are shipping two versions of camel & cxf karaf features. Thanks!