### PR TITLE
ENTESB-7922 Align org.ops4.pax.keycloak in fuse-karaf

### DIFF
--- a/assemblies/fuse-karaf-framework/src/main/feature/feature.xml
+++ b/assemblies/fuse-karaf-framework/src/main/feature/feature.xml
@@ -29,6 +29,7 @@
     <repository>mvn:org.apache.cxf.karaf/apache-cxf/${version.org.apache.cxf}/xml/features</repository>
     <repository>mvn:org.apache.activemq/artemis-features/${version.org.apache.activemq.artemis}/xml/features</repository>
     <repository>mvn:io.hawt/hawtio-karaf/${version.io.hawt}/xml/features</repository>
+    <repository>mvn:org.ops4j.pax.keycloak/pax-keycloak-features/${version.org.ops4j.pax.keycloak}/xml/features</repository>
 
     <!-- Red Hat Fuse Karaf features -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,7 @@
         <version.org.mockito>2.13.0</version.org.mockito>
         <version.org.ops4j.base>1.5.0</version.org.ops4j.base>
         <version.org.ops4j.pax.exam>4.11.0</version.org.ops4j.pax.exam>
+        <version.org.ops4j.pax.keycloak>0.2.0</version.org.ops4j.pax.keycloak>
         <version.org.ops4j.pax.logging>1.10.1</version.org.ops4j.pax.logging>
         <version.org.ops4j.pax.swissbox>1.8.3</version.org.ops4j.pax.swissbox>
         <version.org.ops4j.pax.transx>0.2.0</version.org.ops4j.pax.transx>


### PR DESCRIPTION
Provide a repository for picking up the aligned org.ops4j.pax.keycloak.