### PR TITLE
[ENTESB-7675] Revert "[ENTESB-8090] Do not use broken endorsed JAXP A…

### DIFF
--- a/assemblies/fuse-karaf/pom.xml
+++ b/assemblies/fuse-karaf/pom.xml
@@ -466,7 +466,7 @@
                         <library>mvn:org.bouncycastle/bcpkix-jdk15on/${version.org.bouncycastle};type:=extension;export:=true;delegate:=false</library>
                         <!-- lib/endorsed -->
                         <library>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xerces/${version.org.apache.servicemix.bundles.xerces};type:=endorsed;export:=true;delegate:=true</library>
-                        <!--<library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxp-api-1.4/${version.org.apache.servicemix.specs};type:=endorsed;export:=true</library>-->
+                        <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxp-api-1.4/${version.org.apache.servicemix.specs};type:=endorsed;export:=true</library>
                         <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxb-api-2.2/${version.org.apache.servicemix.specs};type:=endorsed;export:=true</library>
                         <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxws-api-2.2/${version.org.apache.servicemix.specs};type:=endorsed;export:=true</library>
                         <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.saaj-api-1.3/${version.org.apache.servicemix.specs};type:=endorsed;export:=true</library>


### PR DESCRIPTION
…PI from SMX" - SMX works without Karaf specs

This reverts commit b1071a1025c6453f2cb256454db86e0d0d58b858.