### PR TITLE
Change group of hibernate-validator archive.  

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1131,7 +1131,7 @@
                 <version>${version.org.hibernate}</version>
             </dependency>
             <dependency>
-                <groupId>org.hibernate.validator</groupId>
+                <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-validator</artifactId>
                 <version>${version.org.hibernate.validator}</version>
             </dependency>


### PR DESCRIPTION
hibernate-validator was listed as an artifact that we have a incorrect BOM entry for --

https://issues.jboss.org/browse/ENTESB-9100

It looks like the groupId is org.hibernate.validator for hibernate-validator >= 6.0, but org.hibernate for hibernate-validator < 6.0.    Change the groupId to org.hibernate because we are currently using 5.3.5.