### PR TITLE
ENTESB-9638 Update AMQ 7.1.1 clients in Fuse to AMQ 7.2 so that their are aligned with AMQ 7.2 Broker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 
         <!-- versions of "subprojects" of Red Hat Fuse -->
         <version.io.hawt>2.0.0.fuse-720024</version.io.hawt>
-        <version.org.apache.activemq.artemis>2.4.0.amq-711002-redhat-1</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>2.6.3.redhat-00004</version.org.apache.activemq.artemis>
         <version.org.apache.camel>2.21.0.fuse-720029</version.org.apache.camel>
         <version.org.apache.cxf>3.1.11.fuse-720033</version.org.apache.cxf>
         <version.org.apache.karaf>4.2.0.fuse-720035</version.org.apache.karaf>
@@ -105,7 +105,7 @@
         <version.commons-net>3.6</version.commons-net>
         <version.commons-pool>1.6.0.redhat-9</version.commons-pool>
         <version.io.dropwizard.metrics>3.1.5</version.io.dropwizard.metrics>
-        <version.io.netty>4.1.16.Final-redhat-2</version.io.netty>
+        <version.io.netty>4.1.25.Final-redhat-00003</version.io.netty>
         <version.io.swagger>1.5.18.fuse70-1-redhat-1</version.io.swagger>
         <version.io.undertow>1.4.18.SP7-redhat-1</version.io.undertow>
         <version.javax.el2>2.2.5</version.javax.el2>
@@ -122,7 +122,7 @@
         <version.net.java.dev.jna>4.5.1</version.net.java.dev.jna>
         <version.net.sf.ehcache>2.10.3</version.net.sf.ehcache>
         <version.org.antlr4>4.5.3</version.org.antlr4>
-        <version.org.apache.activemq.amq6>5.11.0.redhat-630344</version.org.apache.activemq.amq6>
+        <version.org.apache.activemq.amq6>5.11.0.redhat-630347</version.org.apache.activemq.amq6>
         <version.org.apache.aries.jpa>2.6.1</version.org.apache.aries.jpa>
         <version.org.apache.aries.proxy.api>1.1.0</version.org.apache.aries.proxy.api>
         <version.org.apache.aries.proxy>1.1.1</version.org.apache.aries.proxy>
@@ -148,8 +148,8 @@
         <version.org.apache.httpcomponents.httpcore>4.4.8</version.org.apache.httpcomponents.httpcore>
         <version.org.apache.logging.log4j>2.9.0</version.org.apache.logging.log4j>
         <version.org.apache.maven>3.5.2</version.org.apache.maven>
-        <version.org.apache.qpid.proton-j>0.26.0</version.org.apache.qpid.proton-j>
-        <version.org.apache.qpid.qpid-jms-client>0.30.0</version.org.apache.qpid.qpid-jms-client>
+        <version.org.apache.qpid.proton-j>0.29.0.redhat-00001</version.org.apache.qpid.proton-j>
+        <version.org.apache.qpid.qpid-jms-client>0.34.0.redhat-00002</version.org.apache.qpid.qpid-jms-client>
         <version.org.apache.santuario>2.0.10</version.org.apache.santuario>
         <version.org.apache.servicemix.bundles.ant>1.7.0_6</version.org.apache.servicemix.bundles.ant>
         <version.org.apache.servicemix.bundles.antlr2>2.7.7_5</version.org.apache.servicemix.bundles.antlr2>


### PR DESCRIPTION
https://issues.jboss.org/browse/ENTESB-9638

Hold for ggrzybek's approval, he is running tests