### PR TITLE
[ENTESB-10197] Override mvn:org.apache.activemq/activemq-client/[5.14…

### DIFF
--- a/assemblies/fuse-karaf-framework/src/main/filtered-resources/resources/etc/org.apache.karaf.features.xml
+++ b/assemblies/fuse-karaf-framework/src/main/filtered-resources/resources/etc/org.apache.karaf.features.xml
@@ -227,6 +227,8 @@
         <!-- for pax-jms-activemq/1.0.0 feature -->
         <bundle originalUri="mvn:org.apache.activemq/activemq-osgi/[5.14,5.16)"
                 replacement="mvn:org.fusesource/activemq-client/${version.org.fusesource.activemq}" mode="maven" />
+        <bundle originalUri="mvn:org.apache.activemq/activemq-client/[5.14,5.16)"
+                replacement="mvn:org.fusesource/activemq-client/${version.org.fusesource.activemq}" mode="maven" />
         <bundle originalUri="wrap:mvn:org.apache.activemq/activemq-client/5.*"
                 replacement="mvn:org.fusesource/activemq-client/${version.org.fusesource.activemq}" mode="maven" />
         <bundle originalUri="mvn:org.bouncycastle/bcpkix-jdk15on/[1.50,1.60)"


### PR DESCRIPTION
…,5.16). But PME has to be disabled as well