### PR TITLE
Bumped redhat version of hawtbuf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
         <version.org.eclipse.jetty>9.4.25.v20191220</version.org.eclipse.jetty>
         <version.org.eclipse.jgit>4.10.0.201712302008-r</version.org.eclipse.jgit>
         <version.org.eclipse.persistence>2.1.0</version.org.eclipse.persistence>
-        <version.org.fusesource.hawtbuf>1.11.0.redhat-1</version.org.fusesource.hawtbuf>
+        <version.org.fusesource.hawtbuf>1.11.0.redhat-2</version.org.fusesource.hawtbuf>
         <version.org.glassfish.web.javax.el>2.2.5</version.org.glassfish.web.javax.el>
         <version.org.hibernate>5.3.13.Final-redhat-00001</version.org.hibernate>
         <version.org.hibernate.common>5.0.4.Final-redhat-00001</version.org.hibernate.common>


### PR DESCRIPTION
Upped hatwbuf version from 1.11.0.redhat-1 to 1.11.0.redhat-2 due to md5 inconsistencies with the redhat-1 version.