### PR TITLE
ENTESB-14027 Prometheus exporter for standalone Fuse 7 on Karaf

### DIFF
--- a/assemblies/fuse-karaf-framework/pom.xml
+++ b/assemblies/fuse-karaf-framework/pom.xml
@@ -206,6 +206,10 @@
                                 <concat destfile="${project.build.outputDirectory}/resources/etc/config.properties" append="true" encoding="UTF-8">
                                     <filelist dir="${project.build.directory}/appended-resources" files="append-header.part" />
                                 </concat>
+                                <concat destfile="${project.build.outputDirectory}/resources/etc/prometheus-config.yml" append="true" encoding="UTF-8">
+                                    <filelist dir="${project.build.directory}/appended-resources" files="append-header.part" />
+                                </concat>
+
                                 <concat destfile="${project.build.outputDirectory}/resources/etc/config.properties" append="true" encoding="UTF-8">
                                     <filelist dir="${project.build.directory}/appended-resources/etc" files="config.properties" />
                                     <filterchain>

--- a/assemblies/fuse-karaf-framework/src/main/appended-resources/etc/prometheus-config.yml
+++ b/assemblies/fuse-karaf-framework/src/main/appended-resources/etc/prometheus-config.yml
@@ -1,0 +1,586 @@
+startDelaySecs: 5
+ssl: false
+blacklistObjectNames: ["java.lang:*"]
+rules:
+# Context level
+  - pattern: 'org.apache.camel<context=([^,]+), type=context, name=([^,]+)><>ExchangesCompleted'
+    name: org.apache.camel.ExchangesCompleted
+    help: Exchanges Completed
+    type: COUNTER
+    labels:
+      context: $1
+      type: context
+  - pattern: 'org.apache.camel<context=([^,]+), type=context, name=([^,]+)><>ExchangesFailed'
+    name: org.apache.camel.ExchangesFailed
+    help: Exchanges Failed
+    type: COUNTER
+    labels:
+      context: $1
+      type: context
+  - pattern: 'org.apache.camel<context=([^,]+), type=context, name=([^,]+)><>ExchangesInflight'
+    name: org.apache.camel.ExchangesInflight
+    help: Exchanges Inflight
+    type: COUNTER
+    labels:
+      context: $1
+      type: context
+  - pattern: 'org.apache.camel<context=([^,]+), type=context, name=([^,]+)><>ExchangesTotal'
+    name: org.apache.camel.ExchangesTotal
+    help: Exchanges Total
+    type: COUNTER
+    labels:
+      context: $1
+      type: context
+  - pattern: 'org.apache.camel<context=([^,]+), type=context, name=([^,]+)><>ExchangesTotal'
+    name: org.apache.camel.ExchangesTotal
+    help: Exchanges Total
+    type: COUNTER
+    labels:
+      context: $1
+      type: context
+  - pattern: 'org.apache.camel<context=([^,]+), type=context, name=([^,]+)><>FailuresHandled'
+    name: org.apache.camel.FailuresHandled
+    help: Failures Handled
+    labels:
+        context: $1
+        type: context
+    type: COUNTER
+  - pattern: 'org.apache.camel<context=([^,]+), type=context, name=([^,]+)><>ExternalRedeliveries'
+    name: org.apache.camel.ExternalRedeliveries
+    help: External Redeliveries
+    labels:
+        context: $1
+        type: context
+    type: COUNTER
+  - pattern: 'org.apache.camel<context=([^,]+), type=context, name=([^,]+)><>MaxProcessingTime'
+    name: org.apache.camel.MaxProcessingTime
+    help: Maximum Processing Time
+    labels:
+        context: $1
+        type: context
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=context, name=([^,]+)><>MeanProcessingTime'
+    name: org.apache.camel.MeanProcessingTime
+    help: Mean Processing Time
+    labels:
+        context: $1
+        type: context
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=context, name=([^,]+)><>MinProcessingTime'
+    name: org.apache.camel.MinProcessingTime
+    help: Minimum Processing Time
+    labels:
+        context: $1
+        type: context
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=context, name=([^,]+)><>LastProcessingTime'
+    name: org.apache.camel.LastProcessingTime
+    help: Last Processing Time
+    labels:
+        context: $1
+        type: context
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=context, name=([^,]+)><>DeltaProcessingTime'
+    name: org.apache.camel.DeltaProcessingTime
+    help: Delta Processing Time
+    labels:
+        context: $1
+        type: context
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=context, name=([^,]+)><>Redeliveries'
+    name: org.apache.camel.Redeliveries
+    help: Redeliveries
+    labels:
+        context: $1
+        type: context
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=context, name=([^,]+)><>TotalProcessingTime'
+    name: org.apache.camel.TotalProcessingTime
+    help: Total Processing Time
+    labels:
+        context: $1
+        type: context
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=consumers, name=([^,]+)><>InflightExchanges'
+    name: org.apache.camel.InflightExchanges
+    help: Inflight Exchanges
+    labels:
+        context: $1
+        type: context
+    type: GAUGE
+
+
+# Route level
+  - pattern: 'org.apache.camel<context=([^,]+), type=routes, name=([^,]+)><>ExchangesCompleted'
+    name: org.apache.camel.ExchangesCompleted
+    help: Exchanges Completed
+    type: COUNTER
+    labels:
+      context: $1
+      route: $2
+      type: routes
+  - pattern: 'org.apache.camel<context=([^,]+), type=routes, name=([^,]+)><>ExchangesFailed'
+    name: org.apache.camel.ExchangesFailed
+    help: Exchanges Failed
+    type: COUNTER
+    labels:
+      context: $1
+      route: $2
+      type: routes
+  - pattern: 'org.apache.camel<context=([^,]+), type=routes, name=([^,]+)><>ExchangesInflight'
+    name: org.apache.camel.ExchangesInflight
+    help: Exchanges Inflight
+    type: COUNTER
+    labels:
+      context: $1
+      route: $2
+      type: routes
+  - pattern: 'org.apache.camel<context=([^,]+), type=routes, name=([^,]+)><>ExchangesTotal'
+    name: org.apache.camel.ExchangesTotal
+    help: Exchanges Total
+    type: COUNTER
+    labels:
+      context: $1
+      route: $2
+      type: routes
+  - pattern: 'org.apache.camel<context=([^,]+), type=routes, name=([^,]+)><>ExchangesTotal'
+    name: org.apache.camel.ExchangesTotal
+    help: Exchanges Total
+    type: COUNTER
+    labels:
+      context: $1
+      route: $2
+      type: routes
+  - pattern: 'org.apache.camel<context=([^,]+), type=routes, name=([^,]+)><>FailuresHandled'
+    name: org.apache.camel.FailuresHandled
+    help: Failures Handled
+    labels:
+        context: $1
+        route: $2
+        type: routes
+    type: COUNTER
+  - pattern: 'org.apache.camel<context=([^,]+), type=routes, name=([^,]+)><>ExternalRedeliveries'
+    name: org.apache.camel.ExternalRedeliveries
+    help: External Redeliveries
+    labels:
+        context: $1
+        route: $2
+        type: routes
+    type: COUNTER
+  - pattern: 'org.apache.camel<context=([^,]+), type=routes, name=([^,]+)><>MaxProcessingTime'
+    name: org.apache.camel.MaxProcessingTime
+    help: Maximum Processing Time
+    labels:
+        context: $1
+        route: $2
+        type: routes
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=routes, name=([^,]+)><>MeanProcessingTime'
+    name: org.apache.camel.MeanProcessingTime
+    help: Mean Processing Time
+    labels:
+        context: $1
+        route: $2
+        type: routes
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=routes, name=([^,]+)><>MinProcessingTime'
+    name: org.apache.camel.MinProcessingTime
+    help: Minimum Processing Time
+    labels:
+        context: $1
+        route: $2
+        type: routes
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=routes, name=([^,]+)><>LastProcessingTime'
+    name: org.apache.camel.LastProcessingTime
+    help: Last Processing Time
+    labels:
+        context: $1
+        route: $2
+        type: routes
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=routes, name=([^,]+)><>DeltaProcessingTime'
+    name: org.apache.camel.DeltaProcessingTime
+    help: Delta Processing Time
+    labels:
+        context: $1
+        route: $2
+        type: routes
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=routes, name=([^,]+)><>Redeliveries'
+    name: org.apache.camel.Redeliveries
+    help: Redeliveries
+    labels:
+        context: $1
+        route: $2
+        type: routes
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=routes, name=([^,]+)><>TotalProcessingTime'
+    name: org.apache.camel.TotalProcessingTime
+    help: Total Processing Time
+    labels:
+        context: $1
+        route: $2
+        type: routes
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=routes, name=([^,]+)><>InflightExchanges'
+    name: org.apache.camel.InflightExchanges
+    help: Inflight Exchanges
+    labels:
+        context: $1
+        route: $2
+        type: routes
+    type: GAUGE
+
+# Processor level
+  - pattern: 'org.apache.camel<context=([^,]+), type=processors, name=([^,]+)><>ExchangesCompleted'
+    name: org.apache.camel.ExchangesCompleted
+    help: Exchanges Completed
+    type: COUNTER
+    labels:
+      context: $1
+      processor: $2
+      type: processors
+  - pattern: 'org.apache.camel<context=([^,]+), type=processors, name=([^,]+)><>ExchangesFailed'
+    name: org.apache.camel.ExchangesFailed
+    help: Exchanges Failed
+    type: COUNTER
+    labels:
+      context: $1
+      processor: $2
+      type: processors
+  - pattern: 'org.apache.camel<context=([^,]+), type=processors, name=([^,]+)><>ExchangesInflight'
+    name: org.apache.camel.ExchangesInflight
+    help: Exchanges Inflight
+    type: COUNTER
+    labels:
+      context: $1
+      processor: $2
+      type: processors
+  - pattern: 'org.apache.camel<context=([^,]+), type=processors, name=([^,]+)><>ExchangesTotal'
+    name: org.apache.camel.ExchangesTotal
+    help: Exchanges Total
+    type: COUNTER
+    labels:
+      context: $1
+      processor: $2
+      type: processors
+  - pattern: 'org.apache.camel<context=([^,]+), type=processors, name=([^,]+)><>ExchangesTotal'
+    name: org.apache.camel.ExchangesTotal
+    help: Exchanges Total
+    type: COUNTER
+    labels:
+      context: $1
+      processor: $2
+      type: processors
+  - pattern: 'org.apache.camel<context=([^,]+), type=processors, name=([^,]+)><>FailuresHandled'
+    name: org.apache.camel.FailuresHandled
+    help: Failures Handled
+    labels:
+        context: $1
+        processor: $2
+        type: processors
+    type: COUNTER
+  - pattern: 'org.apache.camel<context=([^,]+), type=processors, name=([^,]+)><>ExternalRedeliveries'
+    name: org.apache.camel.ExternalRedeliveries
+    help: External Redeliveries
+    labels:
+        context: $1
+        processor: $2
+        type: processors
+    type: COUNTER
+  - pattern: 'org.apache.camel<context=([^,]+), type=processors, name=([^,]+)><>MaxProcessingTime'
+    name: org.apache.camel.MaxProcessingTime
+    help: Maximum Processing Time
+    labels:
+        context: $1
+        processor: $2
+        type: processors
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=processors, name=([^,]+)><>MeanProcessingTime'
+    name: org.apache.camel.MeanProcessingTime
+    help: Mean Processing Time
+    labels:
+        context: $1
+        processor: $2
+        type: processors
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=processors, name=([^,]+)><>MinProcessingTime'
+    name: org.apache.camel.MinProcessingTime
+    help: Minimum Processing Time
+    labels:
+        context: $1
+        processor: $2
+        type: processors
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=processors, name=([^,]+)><>LastProcessingTime'
+    name: org.apache.camel.LastProcessingTime
+    help: Last Processing Time
+    labels:
+        context: $1
+        processor: $2
+        type: processors
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=processors, name=([^,]+)><>DeltaProcessingTime'
+    name: org.apache.camel.DeltaProcessingTime
+    help: Delta Processing Time
+    labels:
+        context: $1
+        processor: $2
+        type: processors
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=processors, name=([^,]+)><>Redeliveries'
+    name: org.apache.camel.Redeliveries
+    help: Redeliveries
+    labels:
+        context: $1
+        processor: $2
+        type: processors
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=processors, name=([^,]+)><>TotalProcessingTime'
+    name: org.apache.camel.TotalProcessingTime
+    help: Total Processing Time
+    labels:
+        context: $1
+        processor: $2
+        type: processors
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=processors, name=([^,]+)><>InflightExchanges'
+    name: org.apache.camel.InflightExchanges
+    help: Inflight Exchanges
+    labels:
+        context: $1
+        processor: $2
+        type: processors
+    type: COUNTER
+
+# Consumers
+  - pattern: 'org.apache.camel<context=([^,]+), type=consumers, name=([^,]+)><>InflightExchanges'
+    name: org.apache.camel.InflightExchanges
+    help: Inflight Exchanges
+    labels:
+        context: $1
+        consumer: $2
+        type: consumers
+    type: GAUGE
+
+# Services
+  - pattern: 'org.apache.camel<context=([^,]+), type=services, name=([^,]+)><>MaxDuration'
+    name: org.apache.camel.MaxDuration
+    help: Maximum Duration
+    labels:
+        context: $1
+        service: $2
+        type: services
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=services, name=([^,]+)><>MeanDuration'
+    name: org.apache.camel.MeanDuration
+    help: Mean Duration
+    labels:
+        context: $1
+        service: $2
+        type: services
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=services, name=([^,]+)><>MinDuration'
+    name: org.apache.camel.MinDuration
+    help: Minimum Duration
+    labels:
+        context: $1
+        service: $2
+        type: services
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=services, name=([^,]+)><>TotalDuration'
+    name: org.apache.camel.TotalDuration
+    help: Total Duration
+    labels:
+        context: $1
+        service: $2
+        type: services
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=services, name=([^,]+)><>ThreadsBlocked'
+    name: org.apache.camel.ThreadsBlocked
+    help: Threads Blocked
+    labels:
+        context: $1
+        service: $2
+        type: services
+    type: GAUGE
+  - pattern: 'org.apache.camel<context=([^,]+), type=services, name=([^,]+)><>ThreadsInterrupted'
+    name: org.apache.camel.ThreadsInterrupted
+    help: Threads Interrupted
+    labels:
+        context: $1
+        service: $2
+        type: services
+    type: GAUGE
+  - pattern: 'org.apache.cxf<bus.id=([^,]+), type=([^,]+), service=([^,]+), port=([^,]+), operation=([^,]+)><>NumLogicalRuntimeFaults'
+    name: org.apache.cxf.NumLogicalRuntimeFaults
+    help: Number of logical runtime faults
+    type: GAUGE
+    labels:
+        bus.id: $1
+        type: $2
+        service: $3
+        port: $4
+        operation: $5
+  - pattern: 'org.apache.cxf<bus.id=([^,]+), type=([^,]+), service=([^,]+), port=([^,]+)><>NumLogicalRuntimeFaults'
+    name: org.apache.cxf.NumLogicalRuntimeFaults
+    help: Number of logical runtime faults
+    type: GAUGE
+    labels:
+       bus.id: $1
+       type: $2
+       service: $3
+       port: $4
+  - pattern: 'org.apache.cxf<bus.id=([^,]+), type=([^,]+), service=([^,]+), port=([^,]+), operation=([^,]+)><>AvgResponseTime'
+    name: org.apache.cxf.AvgResponseTime
+    help: Average Response Time
+    type: GAUGE
+    labels:
+       bus.id: $1
+       type: $2
+       service: $3
+       port: $4
+       operation: $5
+  - pattern: 'org.apache.cxf<bus.id=([^,]+), type=([^,]+), service=([^,]+), port=([^,]+)><>AvgResponseTime'
+    name: org.apache.cxf.AvgResponseTime
+    help: Average Response Time
+    type: GAUGE
+    labels:
+          bus.id: $1
+          type: $2
+          service: $3
+          port: $4
+  - pattern: 'org.apache.cxf<bus.id=([^,]+), type=([^,]+), service=([^,]+), port=([^,]+), operation=([^,]+)><>NumInvocations'
+    name: org.apache.cxf.NumInvocations
+    help: Number of invocations
+    type: GAUGE
+    labels:
+        bus.id: $1
+        type: $2
+        service: $3
+        port: $4
+        operation: $5
+  - pattern: 'org.apache.cxf<bus.id=([^,]+), type=([^,]+), service=([^,]+), port=([^,]+)><>NumInvocations'
+    name: org.apache.cxf.NumInvocations
+    help: Number of invocations
+    type: GAUGE
+    labels:
+        bus.id: $1
+        type: $2
+        service: $3
+        port: $4
+  - pattern: 'org.apache.cxf<bus.id=([^,]+), type=([^,]+), service=([^,]+), port=([^,]+), operation=([^,]+)><>MaxResponseTime'
+    name: org.apache.cxf.MaxResponseTime
+    help: Maximum Response Time
+    type: GAUGE
+    labels:
+        bus.id: $1
+        type: $2
+        service: $3
+        port: $4
+        operation: $5
+  - pattern: 'org.apache.cxf<bus.id=([^,]+), type=([^,]+), service=([^,]+), port=([^,]+)><>MaxResponseTime'
+    name: org.apache.cxf.MaxResponseTime
+    help: Maximum Response Time
+    type: GAUGE
+    labels:
+        bus.id: $1
+        type: $2
+        service: $3
+        port: $4
+  - pattern: 'org.apache.cxf<bus.id=([^,]+), type=([^,]+), service=([^,]+), port=([^,]+), operation=([^,]+)><>MinResponseTime'
+    name: org.apache.cxf.MinResponseTime
+    help: Minimum Response Time
+    type: GAUGE
+    labels:
+        bus.id: $1
+        type: $2
+        service: $3
+        port: $4
+        operation: $5
+  - pattern: 'org.apache.cxf<bus.id=([^,]+), type=([^,]+), service=([^,]+), port=([^,]+), operation=([^,]+)><>MinResponseTime'
+    name: org.apache.cxf.MinResponseTime
+    help: Minimum Response Time
+    type: GAUGE
+    labels:
+        bus.id: $1
+        type: $2
+        service: $3
+        port: $4
+  - pattern: 'org.apache.cxf<bus.id=([^,]+), type=([^,]+), service=([^,]+), port=([^,]+), operation=([^,]+)><>TotalHandlingTime'
+    name: org.apache.cxf.TotalHandlingTime
+    help: Total Handling Time
+    type: GAUGE
+    labels:
+        bus.id: $1
+        type: $2
+        service: $3
+        port: $4
+        operation: $5
+  - pattern: 'org.apache.cxf<bus.id=([^,]+), type=([^,]+), service=([^,]+), port=([^,]+)><>TotalHandlingTime'
+    name: org.apache.cxf.TotalHandlingTime
+    help: Total Handling Time
+    type: GAUGE
+    labels:
+        bus.id: $1
+        type: $2
+        service: $3
+        port: $4
+  - pattern: 'org.apache.cxf<bus.id=([^,]+), type=([^,]+), service=([^,]+), port=([^,]+), operation=([^,]+)><>NumRuntimeFaults'
+    name: org.apache.cxf.NumRuntimeFaults
+    help: Number of runtime faults
+    type: GAUGE
+    labels:
+        bus.id: $1
+        type: $2
+        service: $3
+        port: $4
+        operation: $5
+  - pattern: 'org.apache.cxf<bus.id=([^,]+), type=([^,]+), service=([^,]+), port=([^,]+)><>NumRuntimeFaults'
+    name: org.apache.cxf.NumRuntimeFaults
+    help: Number of runtime faults
+    type: GAUGE
+    labels:
+        bus.id: $1
+        type: $2
+        service: $3
+        port: $4
+  - pattern: 'org.apache.cxf<bus.id=([^,]+), type=([^,]+), service=([^,]+), port=([^,]+), operation=([^,]+)><>NumUnCheckedApplicationFaults'
+    name: org.apache.cxf.NumUnCheckedApplicationFaults
+    help: Number of unchecked application faults
+    type: GAUGE
+    labels:
+        bus.id: $1
+        type: $2
+        service: $3
+        port: $4
+        operation: $5
+  - pattern: 'org.apache.cxf<bus.id=([^,]+), type=([^,]+), service=([^,]+), port=([^,]+)><>NumUnCheckedApplicationFaults'
+    name: org.apache.cxf.NumUnCheckedApplicationFaults
+    help: Number of unchecked application faults
+    type: GAUGE
+    labels:
+        bus.id: $1
+        type: $2
+        service: $3
+        port: $4
+  - pattern: 'org.apache.cxf<bus.id=([^,]+), type=([^,]+), service=([^,]+), port=([^,]+), operation=([^,]+)><>NumCheckedApplicationFaults'
+    name: org.apache.cxf.NumCheckedApplicationFaults
+    help: Number of checked application faults
+    type: GAUGE
+    labels:
+        bus.id: $1
+        type: $2
+        service: $3
+        port: $4
+        operation: $5
+  - pattern: 'org.apache.cxf<bus.id=([^,]+), type=([^,]+), service=([^,]+), port=([^,]+)><>NumCheckedApplicationFaults'
+    name: org.apache.cxf.NumCheckedApplicationFaults
+    help: Number of checked application faults
+    type: GAUGE
+    labels:
+        bus.id: $1
+        type: $2
+        service: $3
+        port: $4

--- a/assemblies/fuse-karaf-framework/src/main/resources/resources/bin/fuse
+++ b/assemblies/fuse-karaf-framework/src/main/resources/resources/bin/fuse
@@ -15,8 +15,31 @@
 #  permissions and limitations under the License.
 #
 
-DIRNAME=`dirname "$0"`
+detectPrometheusConfig() {
+    if [ -d "${KARAF_HOME}/etc/prometheus-config.yml" ] || [ -d "${KARAF_HOME}/etc/prometheus-config.yaml" ]; then
 
+        if [ -d "${KARAF_HOME}/etc/prometheus-config.yml" ]; then
+            KARAF_PROMETHEUS_CONFIG="${KARAF_HOME}/etc/prometheus-config.yml"
+        else
+            KARAF_PROMETHEUS_CONFIG="${KARAF_HOME}/etc/prometheus-config.yaml"
+        fi
+
+        # if there's no prometheus port set, let's set the port to 9779
+        if [ "x${KARAF_PROMETHEUS_PORT}" = "x" ]; then
+            KARAF_PROMETHEUS_PORT=9779
+        fi
+        KARAF_PROMETHEUS_VERSION="0.13.0"
+
+        KARAF_PROMETHEUS_OPTS="-javaagent:${KARAF_HOME}/lib/jmx_prometheus_javaagent-${KARAF_PROMETHEUS_VERSION}.jar=${KARAF_PROMETHEUS_PORT}:${KARAF_PROMETHEUS_CONFIG}"
+    fi
+}
+
+DIRNAME=`dirname "$0"`
+. "${DIRNAME}/inc"
+locateHome
+detectPrometheusConfig
+
+JAVA_OPTS="${KARAF_PROMETHEUS_OPTS} ${JAVA_OPTS}"
 KARAF_OPTS="$KARAF_OPTS"
 export KARAF_OPTS
 

--- a/assemblies/fuse-karaf-minimal/pom.xml
+++ b/assemblies/fuse-karaf-minimal/pom.xml
@@ -218,6 +218,7 @@
                         <library>mvn:javax.annotation/javax.annotation-api/${version.javax.annotation};type:=endorsed;export:=true</library>
                         <!-- lib -->
                         <library>mvn:org.jboss.fuse.modules/fuse-branding/${project.version};type:=default;export:=false</library>
+                        <library>mvn:io.prometheus.jmx/jmx_prometheus_javaagent/${version.io.prometheus};type:=default;export:=false</library>
                         <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activator/${version.org.apache.servicemix.specs};type:=default;export:=true</library>
                         <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.locator/${version.org.apache.servicemix.specs};type:=default;export:=true</library>
                         <!-- lib/boot -->

--- a/assemblies/fuse-karaf/pom.xml
+++ b/assemblies/fuse-karaf/pom.xml
@@ -524,6 +524,7 @@
                         <library>mvn:javax.annotation/javax.annotation-api/${version.javax.annotation};type:=endorsed;export:=true</library>
                         <!-- lib -->
                         <library>mvn:org.jboss.fuse.modules/fuse-branding/${project.version};type:=default;export:=false</library>
+                         <library>mvn:io.prometheus.jmx/jmx_prometheus_javaagent/${version.io.prometheus};type:=default;export:=false</library>
                         <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activator/${version.org.apache.servicemix.specs};type:=default;export:=true</library>
                         <library>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.locator/${version.org.apache.servicemix.specs};type:=default;export:=true</library>
                         <!-- lib/boot -->

--- a/pom.xml
+++ b/pom.xml
@@ -75,14 +75,14 @@
         -->
 
         <!-- versions of "subprojects" of Red Hat Fuse -->
-        <version.io.hawt>2.0.0.fuse-760023-redhat-00001</version.io.hawt>
+        <version.io.hawt>2.0.0.fuse-780001</version.io.hawt>
         <version.org.apache.activemq.artemis>2.13.0.redhat-00006</version.org.apache.activemq.artemis>
-        <version.org.apache.camel>2.21.0.fuse-760027-redhat-00001</version.org.apache.camel>
-        <version.org.apache.cxf>3.2.7.fuse-760026-redhat-00001</version.org.apache.cxf>
-        <version.org.apache.karaf>4.2.6.fuse-760032-redhat-00001</version.org.apache.karaf>
-        <version.org.fusesource.activemq>7.6.0.fuse-760024-redhat-00001</version.org.fusesource.activemq>
-        <version.org.fusesource.camel-sap>7.6.0.fuse-760024-redhat-00001</version.org.fusesource.camel-sap>
-        <version.org.apache-extras.camel-extra>2.21.0.fuse-760026-redhat-00001</version.org.apache-extras.camel-extra>
+        <version.org.apache.camel>2.21.0.fuse-780002</version.org.apache.camel>
+        <version.org.apache.cxf>3.2.7.fuse-780001</version.org.apache.cxf>
+        <version.org.apache.karaf>4.2.6.fuse-780002</version.org.apache.karaf>
+        <version.org.fusesource.activemq>7.7.0.fuse-780002</version.org.fusesource.activemq>
+        <version.org.fusesource.camel-sap>7.7.0.fuse-780002</version.org.fusesource.camel-sap>
+        <version.org.apache-extras.camel-extra>2.21.0.fuse-780002</version.org.apache-extras.camel-extra>
 
         <!-- versions of normal dependencies of Red Hat Fuse -->
         <version.com.fasterxml.classmate>1.3.4</version.com.fasterxml.classmate>
@@ -114,6 +114,7 @@
         <version.io.dropwizard.metrics>3.2.6</version.io.dropwizard.metrics>
         <version.io.netty>4.1.48.Final-redhat-00001</version.io.netty>
         <version.io.opentracing>0.31.0</version.io.opentracing>
+        <version.io.prometheus>0.13.0</version.io.prometheus>
         <version.io.swagger>1.5.18.fuse70-1-redhat-1</version.io.swagger>
         <version.io.swagger.core.v3>2.0.0</version.io.swagger.core.v3>
         <version.io.undertow>2.0.30.SP1-redhat-00001</version.io.undertow>
@@ -1158,6 +1159,12 @@
                 <groupId>io.undertow</groupId>
                 <artifactId>undertow-websockets-jsr</artifactId>
                 <version>${version.io.undertow}</version>
+            </dependency>
+
+	    <dependency>
+                <groupId>io.prometheus.jmx</groupId>
+                <artifactId>jmx_prometheus_javaagent</artifactId>
+                <version>${version.io.prometheus}</version>
             </dependency>
 
             <!-- EAP/Wildfly dependencies -->


### PR DESCRIPTION
@grgrzybek I need some feedback here, going to summarize the changes 

- adding io.prometheus.jmx:/jmx_prometheus_javaagent to fuse-karaf/lib.    Is this the right place?   JAR is needed for attaching the agent, I don't need karaf to load the JAR.
- adding prometheus-config.yml to etc, that seems like the right place - this is the configuration of what metrics to expose
- changes to bin/fuse - should I try to push this upstream into bin/inc and bin/karaf?
- 7.8 version changes, that's just to get this to build