### PR TITLE
ENTESB-15218: Upgrade Jetty9 to 9.4.35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
         <version.org.codehaus.woodstox.core>4.4.1.redhat-00001</version.org.codehaus.woodstox.core>
         <version.org.codehaus.woodstox.stax2-api>4.2.1</version.org.codehaus.woodstox.stax2-api>
         <version.org.eclipse.jdt.core.compiler>4.6.1.redhat-1</version.org.eclipse.jdt.core.compiler>
-        <version.org.eclipse.jetty>9.4.30.v20200611</version.org.eclipse.jetty>
+        <version.org.eclipse.jetty>9.4.35.v20201120</version.org.eclipse.jetty>
         <version.org.eclipse.jgit>5.1.3.201810200350-r</version.org.eclipse.jgit>
         <version.org.eclipse.persistence>2.1.0</version.org.eclipse.persistence>
         <version.org.fusesource.hawtbuf>1.11.0.redhat-2</version.org.fusesource.hawtbuf>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-15218