### PR TITLE
[ENTESB-16187] Blacklist pax-jdbc-pool-aries feature because of Valid…

### DIFF
--- a/assemblies/fuse-karaf/pom.xml
+++ b/assemblies/fuse-karaf/pom.xml
@@ -483,6 +483,9 @@
                         <feature>pax-jms-activemq</feature>
                         <feature>pax-jms-oracleaq</feature>
 
+                        <!-- Unsupported PAX JDBC features -->
+                        <feature>pax-jdbc-pool-aries</feature>
+
                         <!-- Unsupported Karaf features -->
                         <feature>minimal</feature>
                         <feature>standard</feature>


### PR DESCRIPTION
…ation API 1 dependency. We use Validation API 2