### PR TITLE
[ENTESB-16621] CVE-2017-18640 prometheus-jmx-exporter: snakeyaml: Billion laughs attack via alias feature [fuse-7]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <version.io.fabric8.kubernetes-client>4.6.2.fuse-790015</version.io.fabric8.kubernetes-client>
         <version.io.netty>4.1.63.Final-redhat-00001</version.io.netty>
         <version.io.opentracing>0.31.0</version.io.opentracing>
-        <version.io.prometheus>0.13.0</version.io.prometheus>
+        <version.io.prometheus>0.14.0.redhat-00002</version.io.prometheus>
         <version.io.swagger>1.6.2</version.io.swagger>
         <version.io.swagger.core.v3>2.1.9</version.io.swagger.core.v3>
         <version.io.undertow>2.2.5.Final-redhat-00001</version.io.undertow>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-16621

From issue comments:
> ... io.prometheus.jmx:jmx_prometheus_javaagent:jar:0.14.0.redhat-00002 which bumps the snakeyaml version to org.yaml:snakeyaml:jar:1.26.0.redhat-00002, would it be possible to align to this version?