### PR TITLE
ENTESB-14417: CVE-2020-14340 xnio: file descriptor leak caused by gro…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1976,6 +1976,17 @@
                 <version>${version.io.swagger.core.v3}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.jboss.xnio</groupId>
+                <artifactId>xnio-api</artifactId>
+                <version>${version.org.jboss.xnio}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.xnio</groupId>
+                <artifactId>xnio-nio</artifactId>
+                <version>${version.org.jboss.xnio}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
…wing amounts of NIO Selector file handles may lead to DoS [fuse-7]