### PR TITLE
ENTESB-17312: CVE-2021-37136 netty-codec: Bzip2Decoder doesn't allow …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <version.io.dropwizard.metrics>3.2.6</version.io.dropwizard.metrics>
         <version.io.fabric8.kubernetes-model>4.6.2</version.io.fabric8.kubernetes-model>
         <version.io.fabric8.kubernetes-client>4.6.2.fuse-790015</version.io.fabric8.kubernetes-client>
-        <version.io.netty>4.1.67.Final-redhat-00001</version.io.netty>
+        <version.io.netty>4.1.68.Final-redhat-00001</version.io.netty>
         <version.io.opentracing>0.31.0</version.io.opentracing>
         <version.io.prometheus>0.14.0.redhat-00002</version.io.prometheus>
         <version.io.swagger>1.6.2</version.io.swagger>


### PR DESCRIPTION
…setting size restrictions for decompressed data [fuse-7]