### PR TITLE
ENTESB-17593: CVE-2021-3859 undertow: client side invocation timeout …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <version.io.prometheus>0.14.0.redhat-00002</version.io.prometheus>
         <version.io.swagger>1.6.2</version.io.swagger>
         <version.io.swagger.core.v3>2.1.9</version.io.swagger.core.v3>
-        <version.io.undertow>2.2.12.Final-redhat-00001</version.io.undertow>
+        <version.io.undertow>2.2.16.Final-redhat-00001</version.io.undertow>
         <!-- version of Undertow used in Pax Web feature, to override it correctly -->
         <version.io.undertow-pax-web>2.2.12.Final</version.io.undertow-pax-web>
         <version.jakarta.annotation>1.3.5.redhat-00003</version.jakarta.annotation>


### PR DESCRIPTION
…raised when calling over HTTP2 [fuse-7]